### PR TITLE
Upgrade XStream version from 1.3.1 to 1.4.11.1 for the sake of security

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -319,7 +319,7 @@
 		<dependency>
 			<groupId>com.thoughtworks.xstream</groupId>
 			<artifactId>xstream</artifactId>
-			<version>1.3.1</version>
+			<version>1.4.11.1</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>

--- a/src/main/java/com/alibaba/cobar/client/router/config/CobarInteralRouterXmlFactoryBean.java
+++ b/src/main/java/com/alibaba/cobar/client/router/config/CobarInteralRouterXmlFactoryBean.java
@@ -54,6 +54,10 @@ public class CobarInteralRouterXmlFactoryBean extends
         xstream.addImplicitCollection(InternalRules.class, "rules");
         xstream.useAttributeFor(InternalRule.class, "merger");
 
+        // To eliminate the warning: Security framework of XStream not initialized, XStream is probably vulnerable
+        XStream.setupDefaultSecurity(xstream);
+        xstream.allowTypes(new Class[]{InternalRule.class});
+
         InternalRules internalRules = (InternalRules) xstream.fromXML(configLocation
                 .getInputStream());
         List<InternalRule> rules = internalRules.getRules();

--- a/src/main/java/com/alibaba/cobar/client/router/config/DefaultCobarClientInternalRouterXmlFactoryBean.java
+++ b/src/main/java/com/alibaba/cobar/client/router/config/DefaultCobarClientInternalRouterXmlFactoryBean.java
@@ -62,6 +62,10 @@ public class DefaultCobarClientInternalRouterXmlFactoryBean extends
         xstream.addImplicitCollection(InternalRules.class, "rules");
         xstream.useAttributeFor(InternalRule.class, "merger");
 
+        // To eliminate the warning: Security framework of XStream not initialized, XStream is probably vulnerable
+        XStream.setupDefaultSecurity(xstream);
+        xstream.allowTypes(new Class[]{InternalRule.class});
+
         List<InternalRule> rules = new ArrayList<InternalRule>();
 
         if (getConfigLocation() != null) {


### PR DESCRIPTION
The XStream has been upgraded to 1.4.11.1 for the sake of security issue. 

We need to set up default security and allow types so that the following warning would not be prompted:

Security framework of XStream not initialized, XStream is probably vulnerable.